### PR TITLE
Added type check to let* capital in resize-window

### DIFF
--- a/resize-window.el
+++ b/resize-window.el
@@ -192,7 +192,8 @@ to enlarge right."
     (while reading-characters
       (let* ((char (resize-window--match-alias (read-key)))
              (choice (assoc char resize-window-dispatch-alist))
-             (capital (assoc (+ char 32) resize-window-dispatch-alist)))
+             (capital (when (numberp char) 
+                        (assoc (+ char 32) resize-window-dispatch-alist))))
         (cond
          (choice (resize-window--execute-action choice))
          ((and capital (resize-window--allows-capitals capital))


### PR DESCRIPTION
Whenever the user clicks inside of an emacs window, that counts as a
(read-key) and returns a seq instead of a number. When we bind `capital`
in the let*, we pre-suppose that char is a number, so then we try to call
- on a number and a list. This would make lisp very angry and we were
  stuck with a gross overlay.

This commit adds a type check in the definition of `capital` using numberp
and if char isn't a number, capital defaults to 0, exiting resize mode.
